### PR TITLE
added support for PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   },
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "monolog/monolog": "2.*",
     "http-interop/http-factory-guzzle": "~1.0.0",
     "php-http/guzzle7-adapter": "^1.0",


### PR DESCRIPTION
Добавил поддержку PHP 8.

### Проверка совместимости

```bash
composer require --dev phpcsstandards/phpcsutils:"^1.0@dev"
composer require --dev phpcompatibility/php-compatibility:dev-develop
```

Проверка на совместимость с PHP 8.2 (Запуск на PHP7.4)
```bash
./vendor/bin/phpcs -d memory_limit=-1 --extensions=php -p -n --parallel=16 --standard=PHPCompatibility --runtime-set testVersion 8.2 ./
```

<img width="950" alt="Screenshot_1" src="https://github.com/WhoTrades/monolog-extensions/assets/11175016/9eaabe07-df5e-4756-99e9-57c7eb326ab1">

Есть ошибки пакета nikic/php-parser, который тянется пакетом phpunit.
По идее ошибок не должно быть, т.к. phpunit9 поддерживает PHP8
https://phpunit.de/supported-versions.html

Ошибок в коде текущего пакета нет.
